### PR TITLE
Change default BGP ASN From 64512 to 64525

### DIFF
--- a/deployment/transit-vpc-primary-account-existing-vpc.template
+++ b/deployment/transit-vpc-primary-account-existing-vpc.template
@@ -33,7 +33,7 @@
     "BgpAsn" : {
       "Description" : "BGP ASN to use for Transit VPC.",
       "Type" : "String",
-      "Default" : "64512"
+      "Default" : "64545"
     },
     "CreateVPCEndpoint" : {
       "Description" : "Do you want an S3 endpoint created in this VPC?",

--- a/deployment/transit-vpc-primary-account-existing-vpc.template
+++ b/deployment/transit-vpc-primary-account-existing-vpc.template
@@ -33,7 +33,7 @@
     "BgpAsn" : {
       "Description" : "BGP ASN to use for Transit VPC.",
       "Type" : "String",
-      "Default" : "64545"
+      "Default" : "64525"
     },
     "CreateVPCEndpoint" : {
       "Description" : "Do you want an S3 endpoint created in this VPC?",

--- a/deployment/transit-vpc-primary-account.template
+++ b/deployment/transit-vpc-primary-account.template
@@ -33,7 +33,7 @@
     "BgpAsn" : {
       "Description" : "BGP ASN to use for Transit VPC.",
       "Type" : "String",
-      "Default" : "64512"
+      "Default" : "64545"
     },
     "VpcCidr" : {
       "Description" : "CIDR block for Transit VPC.",

--- a/deployment/transit-vpc-primary-account.template
+++ b/deployment/transit-vpc-primary-account.template
@@ -33,7 +33,7 @@
     "BgpAsn" : {
       "Description" : "BGP ASN to use for Transit VPC.",
       "Type" : "String",
-      "Default" : "64545"
+      "Default" : "64525"
     },
     "VpcCidr" : {
       "Description" : "CIDR block for Transit VPC.",


### PR DESCRIPTION
Recently AWS changed the default BGP ASN to 64512 (06-30).  While the default can be changed in the CloudFormation Template, it will cause a conflict in the network that can be avoided by starting with a different default. 

See the following for details on the change:
https://docs.aws.amazon.com/vpc/latest/userguide/VPC_VPN.html